### PR TITLE
Weekly release 2022-09-05

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '2.0.13'
+__version__ = '2.0.14'
 
 with open('README.md', 'r') as f:
     __long_description__ = f.read()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def nhm_github(name, tag):
 
 dependencies = dict([
     nhm_github('ckanext-ckanpackager', 'v2.1.3'),
-    nhm_github('ckanext-versioned-datastore', 'v3.6.0'),
+    nhm_github('ckanext-versioned-datastore', 'v3.6.1'),
 ])
 
 setup(


### PR DESCRIPTION
Bump ckanext-versioned-datastore to [v3.6.1](https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/releases/tag/v3.6.1).