### PR TITLE
Track package version in CITATION.cff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ update_changelog_on_bump = true
 changelog_incremental = true
 version_files = [
     "pyproject.toml:version",
-    "CITATION.cff"
+    "CITATION.cff:^version"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_incremental = true
 version_files = [
-    "pyproject.toml:version"
+    "pyproject.toml:version",
+    "CITATION.cff"
 ]
 
 [tool.black]


### PR DESCRIPTION
Patch for previous PR - the version number in CITATION.cff was not noted in pyproject.toml, so commitizen would not know about it and therefore would not update it. _May_ cause a conflict if the cff-version is ever the same as the package version (current cff-version is 1.2.0).