### PR TITLE
Patch release 2023-10-05

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
     "importlib-resources",
     "requests",
     "tqdm>=4.55.1",
-    "ckanext-ckanpackager~=3.0.0",
-    "ckanext-versioned-datastore~=5.1.0",
+    "ckanext-ckanpackager>=3.0.0",
+    "ckanext-versioned-datastore>=5.1.0",
     "ckantools>=0.3.0"
 ]
 


### PR DESCRIPTION
Changes the version specifiers for NHM CKAN extensions in pyproject.toml from `~=` to `>=`. This should avoid having to do unnecessary releases just to increase a version number when it doesn't actually affect this extension.

This should be fairly safe to do for our own extensions. If this extension _does_ use new functionality from a new release, the version specifier should still be increased. This just avoids having to do it when it doesn't matter.