### PR TITLE
Catch validation errors when counting records

### DIFF
--- a/ckanext/statistics/lib/dataset_statistics.py
+++ b/ckanext/statistics/lib/dataset_statistics.py
@@ -73,8 +73,13 @@ class DatasetStatistics(Statistics):
                                 search = toolkit.get_action('datastore_search')(
                                     {}, {'resource_id': resource['id'], 'limit': 0}
                                 )
-                            except (toolkit.ObjectNotFound, SearchIndexError):
-                                # not every file is ingested into the datastore, ignore these errors
+                            except (
+                                toolkit.ObjectNotFound,
+                                SearchIndexError,
+                                toolkit.ValidationError,
+                            ):
+                                # not every file is ingested into the datastore, ignore
+                                # these errors
                                 continue
 
                             resources.append(


### PR DESCRIPTION
Since the new ckanext-versioned-datastore version, datastore_search now produces a validation error if the resource you're trying to search isn't in the datastore, so we need to catch it here.