### PR TITLE
refactor: remove dependency on ckanext-ckanpackager by copying its model

### DIFF
--- a/ckanext/statistics/lib/download_statistics.py
+++ b/ckanext/statistics/lib/download_statistics.py
@@ -13,7 +13,7 @@ from ckan.plugins import toolkit
 from importlib_resources import files
 from sqlalchemy import sql
 
-from ckanext.ckanpackager.model.stat import CKANPackagerStat
+from ckanext.statistics.model.ckanpackager import CKANPackagerStat
 from ckanext.versioned_datastore.model.downloads import DownloadRequest
 
 from ..lib.statistics import Statistics

--- a/ckanext/statistics/model/ckanpackager.py
+++ b/ckanext/statistics/model/ckanpackager.py
@@ -1,0 +1,35 @@
+# !/usr/bin/env python1
+# encoding: utf-8
+#
+# This file is part of ckanext-statistics
+# Created by the Natural History Museum in London, UK
+
+from ckan.model import DomainObject, meta
+from sqlalchemy import Column, DateTime, Integer, Table, UnicodeText, func
+
+"""
+This table has been copied from the now deprecated ckanext-ckanpackager extension to
+enable ongoing compatibility without having to depend on that extension.
+"""
+
+
+ckanpackager_stats_table = Table(
+    'ckanpackager_stats',
+    meta.metadata,
+    Column('id', Integer, primary_key=True),
+    # the current timestamp
+    Column('inserted_on', DateTime, default=func.now()),
+    Column('count', Integer),
+    Column('resource_id', UnicodeText),
+)
+
+
+class CKANPackagerStat(DomainObject):
+    """
+    Object for a datastore download row.
+    """
+
+    pass
+
+
+meta.mapper(CKANPackagerStat, ckanpackager_stats_table)

--- a/ckanext/statistics/model/ckanpackager.py
+++ b/ckanext/statistics/model/ckanpackager.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python1
+# !/usr/bin/env python
 # encoding: utf-8
 #
 # This file is part of ckanext-statistics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "importlib-resources",
     "requests",
     "tqdm>=4.55.1",
-    "ckanext-ckanpackager>=3.0.0",
     "ckanext-versioned-datastore>=5.1.0",
     "ckantools>=0.4.1"
 ]

--- a/tests/test_download_statistics.py
+++ b/tests/test_download_statistics.py
@@ -11,8 +11,11 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from ckanext.ckanpackager.model.stat import CKANPackagerStat, ckanpackager_stats_table
 from ckanext.statistics.lib.download_statistics import DownloadStatistics, MonthlyStats
+from ckanext.statistics.model.ckanpackager import (
+    CKANPackagerStat,
+    ckanpackager_stats_table,
+)
 from ckanext.statistics.model.gbif_download import GBIFDownload, gbif_downloads_table
 from ckanext.versioned_datastore.model import details, downloads, slugs, stats
 from ckanext.versioned_datastore.model.downloads import (

--- a/tests/test_download_statistics.py
+++ b/tests/test_download_statistics.py
@@ -322,7 +322,7 @@ def with_needed_tables(reset_db):
             table.create()
 
 
-@pytest.mark.ckan_config('ckan.plugins', 'statistics versioned_datastore ckanpackager')
+@pytest.mark.ckan_config('ckan.plugins', 'statistics versioned_datastore')
 @pytest.mark.usefixtures('with_needed_tables', 'with_plugins')
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
 class TestDownloadStatistics(object):


### PR DESCRIPTION
The only part of the ckanext-ckanpackager this extension used was the model so now that the ckanext-ckanpackager extensions is deprecated, just copy the model over to this extension to enable us to remove the deprecated dependency. In the long run we'll tidy this up but this works as a short term fix.

Closes: #65