### PR TITLE
Include database migration files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ exclude = ["tests", "docs"]
 [tool.setuptools.package-data]
 "ckanext.statistics.data" = ["*", "**/*"]
 "ckanext.statistics.theme" = ["*", "**/*"]
+"ckanext.statistics.migration" = ["*", "**/*"]
 
 [tool.commitizen]
 name = "cz_nhm"


### PR DESCRIPTION
Alembic migration files were not being included in the built package pushed to PyPI. This fixes that.