### PR TITLE
Mixed downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _A CKAN extension for accessing instance statistics._
 <!--overview-start-->
 Shows statistics for datasets and downloads on the CKAN instance.
 
-**NB**: This extension currently only works with the Natural History Museum's theme extension [ckanext-nhm](https://github.com/NaturalHistoryMuseum/ckanext-nhm).
+**NB**: This extension currently only works for the Natural History Museum, London, due to [embedded data](https://github.com/NaturalHistoryMuseum/ckanext-statistics/issues/64).
 
 <!--overview-end-->
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,23 @@ These are the options that can be specified in your .ini config file.
 
 ## Cache settings
 
-These settings are used to directly configure a [beaker cache region](https://beaker.readthedocs.io/en/latest/modules/cache.html) named `ckanext_statistics`. Please see their [configuration docs](https://beaker.readthedocs.io/en/latest/configuration.html) for more information and additional options.
+This extension uses two named [Beaker cache regions](https://beaker.readthedocs.io/en/latest/modules/cache.html): `statistics_short` (intended for relatively short-term caching, e.g. 1 day) and `statistics_long` (intended for more persistent, long-term caching, e.g. 1 week). Neither of these have any default settings configured, and they can either be configured together or separately.
+
+To define a setting for both caches:
 
 | Name                              | Description                                       | Example                    |
 |-----------------------------------|---------------------------------------------------|----------------------------|
 | `ckanext.statistics.cache.type`   | Cache backend.                                    | `ext:redis`                |
 | `ckanext.statistics.cache.url`    | URL for the backend.                              | `redis://localhost:6379/0` |
-| `ckanext.statistics.cache.expire` | Time until the cache content expires, in seconds. | `3600`                     |
+
+To define settings separately:
+
+| Name                                                       | Description                                               | Example  |
+|------------------------------------------------------------|-----------------------------------------------------------|----------|
+| `ckanext.statistics.cache._region.statistics_short.expire` | Expire time in seconds for the `statistics_short` region. | `86400`  |
+| `ckanext.statistics.cache._region.statistics_long.expire`  | Expire time in seconds for the `statistics_long` region.  | `604800` |
+
+Please see Beaker's [configuration docs](https://beaker.readthedocs.io/en/latest/configuration.html) for more information and additional options.
 
 <!--configuration-end-->
 

--- a/ckanext/statistics/lib/download_statistics.py
+++ b/ckanext/statistics/lib/download_statistics.py
@@ -175,6 +175,10 @@ class DownloadStatistics(Statistics):
                 'records': 0,
                 'download_events': 0,
             },
+            'mixed': {
+                'records': 0,
+                'download_events': 0,
+            },
             'gbif': {
                 'records': 0,
                 'download_events': 0,
@@ -235,21 +239,15 @@ class DownloadStatistics(Statistics):
         stats_dict = defaultdict(self._init_stats_dict)
         for download in base_query.filter(*filters):
             key = self._date_format(date=download.created)
-            has_research = False
-            has_collections = False
+            res_types = set()
             for rid, rc in download.core_record.resource_totals.items():
                 resource_type = self.resource_type(rid)
-                if resource_type == 'research':
-                    has_research = True
-                elif resource_type == 'collections':
-                    has_collections = True
+                res_types.add(resource_type)
                 stats_dict[key][resource_type]['records'] += rc or 0
-            # if a download contains both research and collections data, it gets
-            # counted twice
-            if has_research:
-                stats_dict[key]['research']['download_events'] += 1
-            if has_collections:
-                stats_dict[key]['collections']['download_events'] += 1
+            if len(res_types) > 0:
+                stats_dict[key]['mixed']['download_events'] += 1
+            else:
+                stats_dict[key][res_types[0]]['download_events'] += 1
         return dict(stats_dict)
 
     @cache_region('statistics_long', 'dl_stats_gbif')

--- a/ckanext/statistics/lib/download_statistics.py
+++ b/ckanext/statistics/lib/download_statistics.py
@@ -244,10 +244,10 @@ class DownloadStatistics(Statistics):
                 resource_type = self.resource_type(rid)
                 res_types.add(resource_type)
                 stats_dict[key][resource_type]['records'] += rc or 0
-            if len(res_types) > 0:
+            if len(res_types) > 1:
                 stats_dict[key]['mixed']['download_events'] += 1
             else:
-                stats_dict[key][res_types[0]]['download_events'] += 1
+                stats_dict[key][list(res_types)[0]]['download_events'] += 1
         return dict(stats_dict)
 
     @cache_region('statistics_long', 'dl_stats_gbif')

--- a/ckanext/statistics/lib/download_statistics.py
+++ b/ckanext/statistics/lib/download_statistics.py
@@ -246,7 +246,7 @@ class DownloadStatistics(Statistics):
                 stats_dict[key][resource_type]['records'] += rc or 0
             if len(res_types) > 1:
                 stats_dict[key]['mixed']['download_events'] += 1
-            else:
+            elif len(res_types) == 1:
                 stats_dict[key][list(res_types)[0]]['download_events'] += 1
         return dict(stats_dict)
 

--- a/ckanext/statistics/lib/download_statistics.py
+++ b/ckanext/statistics/lib/download_statistics.py
@@ -313,7 +313,7 @@ class DownloadStatistics(Statistics):
         if year:
             return {
                 self._date_format(year=year, month=ix + 1): self._init_stats_dict()
-                for ix in range(12)
+                for ix in range(today.month if year == today.year else 12)
             }
 
         # find the years we've already got data for (current year if none)

--- a/tests/test_download_statistics.py
+++ b/tests/test_download_statistics.py
@@ -237,12 +237,16 @@ class TestDownloadStatistics(object):
 
         assert '1/2019' in returned_stats
         assert returned_stats['1/2019']['collections'] == {
-            'download_events': 1,
+            'download_events': 0,
             'records': 100,
         }
         assert returned_stats['1/2019']['research'] == {
-            'download_events': 1,
+            'download_events': 0,
             'records': 32,
+        }
+        assert returned_stats['1/2019']['mixed'] == {
+            'download_events': 1,
+            'records': 0,
         }
         assert '3/2019' in returned_stats
         assert returned_stats['3/2019']['research'] == {


### PR DESCRIPTION
The primary change for this PR is the addition of the "mixed" category of downloads (alongside "collections", "research" and "gbif"), which is to account for downloaded files that contain records from both collections _and_ research datasets. This only affects `download_events`.

For example:

- `resource_1` is a collections resource
- `resource_2` is a research resource
- `download_1` contains 100 records from `resource_1`
- `download_2` contains 100 records from `resource_2`
- `download_3` contains 100 records from `resource_1` and 100 records from `resource_2`
- so the total events is 3 (2 collections and 2 research), total records is 400 (200 collections and 200 research)

Previous this would have been represented as (ignoring the "gbif" category):

```python
{
    "collections": {
        "download_events": 2,  # download_1 and download_3
        "records": 200  # download_1 and download_3
    },
    "research": {
        "download_events": 2,  # download_2 and download_3
        "records": 200  # download_2 and download_3
    }
}
```

There's no way to establish that the total number of download events of any type is **3**,

This is now represented as (again ignoring the "gbif" category, which is unchanged):

```python
{
    "collections": {
        "download_events": 1,  # download_1
        "records": 200  # download_1 and download_3
    },
    "research": {
        "download_events": 1,  # download_2
        "records": 200  # download_2 and download_3
    },
    "mixed": {
        "download_events": 1,  # download_3
        "records": 0  # always 0
    }
}
```

Representing it like this means that the totals are accurate, even if the representation is initially somewhat confusing. From this, we can calculate that the total number of all download events is 3, the total number of download events involving a collections dataset is 2, and the total number of download events involving a research dataset is 2.